### PR TITLE
Add column scaling option of the LSI matrix

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,7 +14,7 @@ License: MIT
 LinkingTo: Rcpp, RcppArmadillo
 LazyData: TRUE
 URL: https://www.ArchRProject.com
-RoxygenNote: 7.3.2
+RoxygenNote: 7.3.3
 Encoding: UTF-8
 Imports:
     BiocGenerics,

--- a/R/Clustering.R
+++ b/R/Clustering.R
@@ -18,10 +18,11 @@
 #' to keep track of the seed used so that you can reproduce results downstream.
 #' @param method A string indicating the clustering method to be used. Supported methods are "Seurat" and "Scran".
 #' @param dimsToUse A vector containing the dimensions from the `reducedDims` object to use in clustering.
-#' @param scaleDims A boolean value that indicates whether to z-score the reduced dimensions for each cell. This is useful for minimizing the contribution
-#' of strong biases (dominating early PCs) and lowly abundant populations. However, this may lead to stronger sample-specific biases since
-#' it is over-weighting latent PCs. If set to `NULL` this will scale the dimensions based on the value of `scaleDims` when the `reducedDims` were
-#' originally created during dimensionality reduction. This idea was introduced by Timothy Stuart.
+#' @param scaleDims A boolean value that indicates whether to z-score the reduced dimensions. The default is set to `NULL`, and will scale the dimensions 
+#' based on the value of `scaleDims` when the `reducedDims` were originally created during dimensionality reduction. This idea was introduced by Timothy Stuart.
+#' @param scaleBy A character string indicating if the reduced dimensions should be scaled in either the row direction (default) or the column direction when `scaleDims = TRUE`.
+#' In the case of SVD matrix, the default is to perform scaling for each cell, rather than on the components as in the `signac::RunSVD` implementation.
+#' You can use `scaleBy = "column"` to perform scaling for each component. Like, `scaleDims`, the saved value of `scaleBy` will be used if set to `scaleBy = NULL`.
 #' @param corCutOff A numeric cutoff for the correlation of each dimension to the sequencing depth. If the dimension has a correlation to
 #' sequencing depth that is greater than the `corCutOff`, it will be excluded from analysis.
 #' @param knnAssign The number of nearest neighbors to be used during clustering for assignment of outliers (clusters with less than nOutlier cells).
@@ -74,6 +75,7 @@ addClusters <- function(
   method = "Seurat",
   dimsToUse = NULL,
   scaleDims = NULL, 
+  scaleBy = NULL,
   corCutOff = 0.75,
   knnAssign = 10, 
   nOutlier = 5, 
@@ -113,6 +115,7 @@ addClusters <- function(
   .validInput(input = method, name = "method", valid = c("character"))
   .validInput(input = dimsToUse, name = "dimsToUse", valid = c("numeric", "null"))
   .validInput(input = scaleDims, name = "scaleDims", valid = c("boolean", "null"))
+  .validInput(input = scaleBy, name = "scaleBy", valid = c("character", "null"))
   .validInput(input = corCutOff, name = "corCutOff", valid = c("numeric", "null"))
   .validInput(input = knnAssign, name = "knnAssign", valid = c("integer"))
   .validInput(input = nOutlier, name = "nOutlier", valid = c("integer"))
@@ -158,7 +161,8 @@ addClusters <- function(
           reducedDims = reducedDims, 
           dimsToUse = dimsToUse, 
           corCutOff = corCutOff, 
-          scaleDims = scaleDims
+          scaleDims = scaleDims,
+          scaleBy = scaleBy
       )
   
   }else if(inherits(input, "matrix")){

--- a/R/DoubletsScores.R
+++ b/R/DoubletsScores.R
@@ -15,9 +15,11 @@
 #' @param dimsToUse A vector containing the dimensions from the `reducedDims` object to use in clustering.
 #' @param LSIMethod A number or string indicating the order of operations in the TF-IDF normalization.
 #' Possible values are: 1 or "tf-logidf", 2 or "log(tf-idf)", and 3 or "logtf-logidf".
-#' @param scaleDims A boolean that indicates whether to z-score the reduced dimensions for each cell during the LSI
-#' method performed for doublet determination. This is useful for minimizing the contribution of strong biases (dominating early PCs)
-#' and lowly abundant populations. However, this may lead to stronger sample-specific biases since it is over-weighting latent PCs.
+#' @param scaleDims A boolean value that indicates whether to z-score the reduced dimensions during the LSI method performed for doublet determination. 
+#' The default is to NOT perform scaling on the SVD matrix. You can use `scaleDims = TRUE` to turn ON scaling.
+#' @param scaleBy A character string indicating if the reduced dimensions should be scaled in either the row direction (default) or the column direction when `scaleDims = TRUE`.
+#' In the case of SVD matrix, the default is to perform scaling for each cell, rather than on the components as in the `signac::RunSVD` implementation.
+#' You can use `scaleBy = "column"` to perform scaling for each component.
 #' @param corCutOff A numeric cutoff for the correlation of each dimension to the sequencing depth. If the dimension has a correlation
 #' to sequencing depth that is greater than the `corCutOff`, it will be excluded from analysis.
 #' @param knnMethod The name of the dimensionality reduction method to be used for k-nearest neighbors calculation. Possible values are "UMAP" or "LSI".
@@ -49,6 +51,7 @@ addDoubletScores <- function(
   dimsToUse = 1:30,
   LSIMethod = 1,
   scaleDims = FALSE,
+  scaleBy = "row",
   corCutOff = 0.75,
   knnMethod = "UMAP",
   UMAPParams = list(n_neighbors = 40, min_dist = 0.4, metric = "euclidean", verbose = FALSE),
@@ -68,6 +71,7 @@ addDoubletScores <- function(
   .validInput(input = dimsToUse, name = "dimsToUse", valid = c("integer", "null"))
   .validInput(input = corCutOff, name = "corCutOff", valid = c("numeric", "null"))
   .validInput(input = scaleDims, name = "scaleDims", valid = c("boolean"))
+  .validInput(input = scaleBy, name = "scaleBy", valid = c("boolean"))
   .validInput(input = knnMethod, name = "knnMethod", valid = c("character"))
   .validInput(input = UMAPParams, name = "UMAPParams", valid = c("list"))
   .validInput(input = LSIParams, name = "LSIParams", valid = c("list"))
@@ -157,6 +161,7 @@ addDoubletScores <- function(
   LSIMethod = 1,
   sampleCells = NULL,
   scaleDims = FALSE,
+  scaleBy = "row",
   k = 10,
   nSample = 1000,
   knnMethod = "UMAP",
@@ -209,6 +214,7 @@ addDoubletScores <- function(
   LSIParams$LSIMethod <- LSIMethod
   LSIParams$dimsToUse <- dimsToUse
   LSIParams$scaleDims <- scaleDims
+  LSIParams$scaleBy <- scaleBy
   LSIParams$corCutOff <- corCutOff
   LSIParams$threads <- subThreads
   LSIParams$verbose <- FALSE
@@ -230,6 +236,7 @@ addDoubletScores <- function(
     corCutOff = corCutOff, 
     dimsToUse = dimsToUse,
     scaleDims = scaleDims,
+    scaleBy = scaleBy,
     returnMatrix = FALSE
   )
   .logThis(LSI, name = paste0(prefix, "LSI Result"), logFile = logFile)
@@ -543,7 +550,7 @@ addDoubletScores <- function(
   gc()
 
   if(LSI$scaleDims){
-    allLSI <- .scaleDims(allLSI)
+    allLSI <- .scaleDims(allLSI, scale = scaleBy)
   }
 
   #Project UMAP
@@ -619,13 +626,13 @@ addDoubletScores <- function(
 
     nSim <- nrow(LSI$matSVD)
     scaleTo <- 10000
-    scaleBy <- scaleTo / nSim
+    scaleRatio <- scaleTo / nSim
 
     #P-Values
     pvalBinomDoub <- lapply(seq_along(countKnn), function(x){
       #Round Prediction
-      countKnnx <- round(countKnn[x] * scaleBy)
-      sumKnnx <- round(sum(countKnn) * scaleBy)
+      countKnnx <- round(countKnn[x] * scaleRatio)
+      sumKnnx <- round(sum(countKnn) * scaleRatio)
       pbinom(countKnnx - 1, sumKnnx, 1 / scaleTo, lower.tail = FALSE)
     }) %>% unlist
 
@@ -657,13 +664,13 @@ addDoubletScores <- function(
 
     nSim <- nrow(LSI$matSVD)
     scaleTo <- 10000
-    scaleBy <- scaleTo / nSim
+    scaleRatio <- scaleTo / nSim
 
     #P-Values
     pvalBinomDoub <- lapply(seq_along(countKnn), function(x){
       #Round Prediction
-      countKnnx <- round(countKnn[x] * scaleBy)
-      sumKnnx <- round(sum(countKnn) * scaleBy)
+      countKnnx <- round(countKnn[x] * scaleRatio)
+      sumKnnx <- round(sum(countKnn) * scaleRatio)
       pbinom(countKnnx - 1, sumKnnx, 1 / scaleTo, lower.tail = FALSE)
     }) %>% unlist
 

--- a/R/Embedding.R
+++ b/R/Embedding.R
@@ -14,10 +14,11 @@
 #' `uwot::umap()`. For more info on this see https://jlmelville.github.io/uwot/abparams.html.
 #' @param metric A number that determines how distance is computed in the `reducedDims` to compute a UMAP. This argument is passed to `metric` in `uwot::umap()`.
 #' @param dimsToUse A vector containing the dimensions from the `reducedDims` object to use in computing the embedding.
-#' @param scaleDims A boolean value that indicates whether to z-score the reduced dimensions for each cell. This is useful for minimizing
-#' the contribution of strong biases (dominating early PCs) and lowly abundant populations. However, this may lead to stronger sample-specific
-#' biases since it is over-weighting latent PCs. If set to `NULL` this will scale the dimensions based on the value of `scaleDims` when the
-#' `reducedDims` were originally created during dimensionality reduction. This idea was introduced by Timothy Stuart.
+#' @param scaleDims A boolean value that indicates whether to z-score the reduced dimensions. The default is set to `NULL`, and will scale the dimensions 
+#' based on the value of `scaleDims` when the `reducedDims` were originally created during dimensionality reduction. This idea was introduced by Timothy Stuart.
+#' @param scaleBy A character string indicating if the reduced dimensions should be scaled in either the row direction (default) or the column direction when `scaleDims = TRUE`.
+#' In the case of SVD matrix, the default is to perform scaling for each cell, rather than on the components as in the `signac::RunSVD` implementation.
+#' You can use `scaleBy = "column"` to perform scaling for each component. Like, `scaleDims`, the saved value of `scaleBy` will be used if set to `scaleBy = NULL`.
 #' @param corCutOff A numeric cutoff for the correlation of each dimension to the sequencing depth. If the dimension has a correlation to
 #' sequencing depth that is greater than the `corCutOff`, it will be excluded from analysis.
 #' @param sampleCells An integer specifying the number of cells to subsample and perform UMAP Embedding on. The remaining cells
@@ -52,6 +53,7 @@ addUMAP <- function(
   metric = "cosine",
   dimsToUse = NULL,
   scaleDims = NULL,
+  scaleBy = NULL,
   corCutOff = 0.75,
   sampleCells = NULL,
   outlierQuantile = 0.9,
@@ -71,6 +73,7 @@ addUMAP <- function(
   .validInput(input = metric, name = "metric", valid = c("character", "null"))
   .validInput(input = dimsToUse, name = "dimsToUse", valid = c("integer", "null"))
   .validInput(input = scaleDims, name = "scaleDims", valid = c("boolean", "null"))
+  .validInput(input = scaleBy, name = "scaleBy", valid = c("character", "null"))
   .validInput(input = corCutOff, name = "corCutOff", valid = c("numeric", "null"))
   .validInput(input = sampleCells, name = "sampleCells", valid = c("integer", "null"))
   .validInput(input = outlierQuantile, name = "outlierQuantile", valid = c("numeric"))
@@ -97,7 +100,8 @@ addUMAP <- function(
       reducedDims = reducedDims, 
       dimsToUse = dimsToUse, 
       corCutOff = corCutOff, 
-      scaleDims = scaleDims
+      scaleDims = scaleDims,
+      scaleBy = scaleBy
   )
   embeddingParams$n_neighbors <- nNeighbors
   embeddingParams$min_dist <- minDist
@@ -183,6 +187,7 @@ addUMAP <- function(
         embeddingParams,
         dimsToUse = dimsToUse,
         scaleDims = scaleDims,
+        scaleBy = scaleBy,
         corCutOff = corCutOff,
         nr=nr,
         nc=nc,
@@ -202,6 +207,7 @@ addUMAP <- function(
         embeddingParams,
         dimsToUse = dimsToUse,
         scaleDims = scaleDims,
+        scaleBy = scaleBy,
         corCutOff = corCutOff,
         nr=nr,
         nc=nc,
@@ -347,10 +353,11 @@ addUMAP <- function(
 #' @param maxIterations An integer describing the maximum number of iterations when computing a TSNE. This argument is passed to `max_iter` in `Rtsne::Rtsne()`.
 #' @param learningRate An integer controlling how much the weights are adjusted at each iteration. This argument is passed to `eta` in `Rtsne::Rtsne()`.
 #' @param dimsToUse A vector containing the dimensions from the `reducedDims` object to use in computing the embedding.
-#' @param scaleDims A boolean value that indicates whether to z-score the reduced dimensions for each cell. This is useful for minimizing
-#' the contribution of strong biases (dominating early PCs) and lowly abundant populations. However, this may lead to stronger sample-specific
-#' biases since it is over-weighting latent PCs. If set to `NULL` this will scale the dimensions based on the value of `scaleDims` when the
-#' `reducedDims` were originally created during dimensionality reduction. This idea was introduced by Timothy Stuart.
+#' @param scaleDims A boolean value that indicates whether to z-score the reduced dimensions. The default is set to `NULL`, and will scale the dimensions 
+#' based on the value of `scaleDims` when the `reducedDims` were originally created during dimensionality reduction. This idea was introduced by Timothy Stuart.
+#' @param scaleBy A character string indicating if the reduced dimensions should be scaled in either the row direction (default) or the column direction when `scaleDims = TRUE`.
+#' In the case of SVD matrix, the default is to perform scaling for each cell, rather than on the components as in the `signac::RunSVD` implementation.
+#' You can use `scaleBy = "column"` to perform scaling for each component. Like, `scaleDims`, the saved value of `scaleBy` will be used if set to `scaleBy = NULL`.
 #' @param corCutOff A numeric cutoff for the correlation of each dimension to the sequencing depth. If the dimension has a correlation to sequencing
 #' depth that is greater than the `corCutOff`, it will be excluded from analysis.
 #' @param verbose A boolean value that indicates whether printing TSNE output.
@@ -380,6 +387,7 @@ addTSNE <- function(
   learningRate = 200,
   dimsToUse = NULL,
   scaleDims = NULL,
+  scaleBy = NULL,
   corCutOff = 0.75,
   saveModel = FALSE,
   verbose = TRUE,
@@ -398,6 +406,7 @@ addTSNE <- function(
   .validInput(input = learningRate, name = "learningRate", valid = c("integer"))
   .validInput(input = dimsToUse, name = "dimsToUse", valid = c("integer", "null"))
   .validInput(input = scaleDims, name = "scaleDims", valid = c("boolean", "null"))
+  .validInput(input = scaleBy, name = "scaleBy", valid = c("character", "null"))
   .validInput(input = corCutOff, name = "corCutOff", valid = c("numeric", "null"))
   .validInput(input = verbose, name = "verbose", valid = c("boolean"))
   .validInput(input = seed, name = "seed", valid = c("integer"))
@@ -424,7 +433,8 @@ addTSNE <- function(
       reducedDims = reducedDims, 
       dimsToUse = dimsToUse, 
       corCutOff = corCutOff, 
-      scaleDims = scaleDims
+      scaleDims = scaleDims,
+      scaleBy = scaleBy
   )
 
   if(tolower(method)!="rtsne"){
@@ -441,7 +451,8 @@ addTSNE <- function(
         reducedDims = reducedDims, 
         dimsToUse = dimsToUse, 
         corCutOff = corCutOff, 
-        scaleDims = scaleDims
+        scaleDims = scaleDims,
+        scaleBy = scaleBy
     )
 
     embeddingParams$pca <- FALSE
@@ -464,7 +475,8 @@ addTSNE <- function(
         reducedDims = reducedDims, 
         dimsToUse = dimsToUse, 
         corCutOff = corCutOff, 
-        scaleDims = scaleDims
+        scaleDims = scaleDims,
+        scaleBy = scaleBy
     )
     
     embeddingParams$assay <- NULL

--- a/R/Harmony.R
+++ b/R/Harmony.R
@@ -5,10 +5,11 @@
 #' @param ArchRProj An `ArchRProject` object containing the dimensionality reduction matrix passed by `reducedDims`.
 #' @param reducedDims The name of the `reducedDims` object (i.e. "IterativeLSI") to retrieve from the designated `ArchRProject`.
 #' @param dimsToUse A vector containing the dimensions from the `reducedDims` object to use in clustering.
-#' @param scaleDims A boolean that indicates whether to z-score the reduced dimensions for each cell. This is useful forminimizing the contribution
-#' of strong biases (dominating early PCs) and lowly abundant populations. However, this may lead to stronger sample-specific biases since
-#' it is over-weighting latent PCs. If set to `NULL` this will scale the dimensions based on the value of `scaleDims` when the `reducedDims` were
-#' originally created during dimensionality reduction. This idea was introduced by Timothy Stuart.
+#' @param scaleDims A boolean value that indicates whether to z-score the reduced dimensions. The default is set to `NULL`, and will scale the dimensions 
+#' based on the value of `scaleDims` when the `reducedDims` were originally created during dimensionality reduction. This idea was introduced by Timothy Stuart.
+#' @param scaleBy A character string indicating if the reduced dimensions should be scaled in either the row direction (default) or the column direction when `scaleDims = TRUE`.
+#' In the case of SVD matrix, the default is to perform scaling for each cell, rather than on the components as in the `signac::RunSVD` implementation.
+#' You can use `scaleBy = "column"` to perform scaling for each component. Like, `scaleDims`, the saved value of `scaleBy` will be used if set to `scaleBy = NULL`.
 #' @param corCutOff A numeric cutoff for the correlation of each dimension to the sequencing depth. If the dimension has a correlation
 #' to sequencing depth that is greater than the `corCutOff`, it will be excluded from analysis.
 #' @param name The name to store harmony output as a `reducedDims` in the `ArchRProject` object.
@@ -38,6 +39,7 @@ addHarmony <- function(
   reducedDims = "IterativeLSI",
   dimsToUse = NULL,
   scaleDims = NULL, 
+  scaleBy = NULL,
   corCutOff = 0.75,
   name = "Harmony",
   groupBy = "Sample",
@@ -50,6 +52,7 @@ addHarmony <- function(
   .validInput(input = reducedDims, name = "reducedDims", valid = c("character"))
   .validInput(input = dimsToUse, name = "dimsToUse", valid = c("numeric", "null"))
   .validInput(input = scaleDims, name = "scaleDims", valid = c("boolean", "null"))
+  .validInput(input = scaleBy, name = "scaleBy", valid = c("character", "null"))
   .validInput(input = corCutOff, name = "corCutOff", valid = c("numeric", "null"))
   .validInput(input = name, name = "name", valid = c("character"))
   .validInput(input = groupBy, name = "groupBy", valid = c("character"))
@@ -69,6 +72,7 @@ addHarmony <- function(
     reducedDims = reducedDims, 
     dimsToUse = dimsToUse, 
     scaleDims = scaleDims, 
+    scaleBy = scaleBy,
     corCutOff = corCutOff
   )
   harmonyParams$verbose <- verbose
@@ -79,21 +83,17 @@ addHarmony <- function(
   harmonyParams$vars_use <- groupBy
   harmonyParams$plot_convergence <- FALSE
 
-  #Call Harmony
+  # Call Harmony
   harmonyMat <- suppressWarnings(do.call(HarmonyMatrix, harmonyParams))
   harmonyParams$data_mat <- NULL
   ArchRProj@reducedDims[[name]] <- SimpleList(
     matDR = harmonyMat, 
     params = harmonyParams,
     date = Sys.time(),
-    scaleDims = NA, #Do not scale dims after
+    scaleDims = NA,  # do not scale dims after
+    scaleBy = "row", # set to default
     corToDepth = NA
   )
   ArchRProj
-
 }
-
-
-
-
 

--- a/R/HiddenUtils.R
+++ b/R/HiddenUtils.R
@@ -99,8 +99,20 @@
   knnIdx
 }
 
+# Performs row-wise (cell) scaling of the singular value decomposition (SVD) matrix, matSVD
 .rowZscores <- function(m = NULL, min = -2, max = 2, limit = FALSE){
   z <- sweep(m - rowMeans(m), 1, matrixStats::rowSds(m),`/`)
+  if(limit){
+    z[z > max] <- max
+    z[z < min] <- min
+  }
+  return(z)
+}
+
+# Performs column-wise (component) scaling of the singular value decomposition (SVD) matrix, matSVD
+# see https://github.com/GreenleafLab/ArchR/issues/2120
+.colZscores <- function(m = NULL, min = -2, max = 2, limit = FALSE){
+  z <- sweep(t(t(m) - colMeans(m)), 2, matrixStats::colSds(m), `/`)
   if(limit){
     z[z > max] <- max
     z[z < min] <- min

--- a/R/Imputation.R
+++ b/R/Imputation.R
@@ -9,10 +9,11 @@
 #' @param ArchRProj An `ArchRProject` object.
 #' @param reducedDims The name of the `reducedDims` object (i.e. "IterativeLSI") to retrieve from the designated `ArchRProject`.
 #' @param dimsToUse A vector containing the dimensions from the `reducedDims` object to use.
-#' @param scaleDims A boolean that indicates whether to z-score the reduced dimensions for each cell. This is useful forminimizing the contribution
-#' of strong biases (dominating early PCs) and lowly abundant populations. However, this may lead to stronger sample-specific biases since
-#' it is over-weighting latent PCs. If set to `NULL` this will scale the dimensions based on the value of `scaleDims` when the `reducedDims` were
-#' originally created during dimensionality reduction. This idea was introduced by Timothy Stuart.
+#' @param scaleDims A boolean value that indicates whether to z-score the reduced dimensions. The default is set to `NULL`, and will scale the dimensions 
+#' based on the value of `scaleDims` when the `reducedDims` were originally created during dimensionality reduction. This idea was introduced by Timothy Stuart.
+#' @param scaleBy A character string indicating if the reduced dimensions should be scaled in either the row direction (default) or the column direction when `scaleDims = TRUE`.
+#' In the case of SVD matrix, the default is to perform scaling for each cell, rather than on the components as in the `signac::RunSVD` implementation.
+#' You can use `scaleBy = "column"` to perform scaling for each component. Like, `scaleDims`, the saved value of `scaleBy` will be used if set to `scaleBy = NULL`.
 #' @param corCutOff A numeric cutoff for the correlation of each dimension to the sequencing depth. If the dimension has a correlation to
 #' sequencing depth that is greater than the `corCutOff`, it will be excluded.
 #' @param td The diffusion time parameter determines the number of smoothing iterations to be performed (see MAGIC from van Dijk et al Cell 2018).
@@ -46,6 +47,7 @@ addImputeWeights <- function(
   reducedDims = "IterativeLSI", 
   dimsToUse = NULL, 
   scaleDims = NULL,
+  scaleBy = NULL,
   corCutOff = 0.75, 
   td = 3,
   ka = 4,
@@ -65,6 +67,7 @@ addImputeWeights <- function(
   .validInput(input = reducedDims, name = "reducedDims", valid = c("character"))
   .validInput(input = dimsToUse, name = "dimsToUse", valid = c("integer", "null"))
   .validInput(input = scaleDims, name = "scaleDims", valid = c("boolean", "null"))
+  .validInput(input = scaleBy, name = "scaleBy", valid = c("character", "null"))
   .validInput(input = corCutOff, name = "corCutOff", valid = c("numeric"))
   .validInput(input = td, name = "td", valid = c("integer"))
   .validInput(input = ka, name = "ka", valid = c("integer"))

--- a/R/IntegrativeAnalysis.R
+++ b/R/IntegrativeAnalysis.R
@@ -19,10 +19,11 @@
 #' @param log2Norm2 A boolean describing whether to log2 normalize matrix 2.
 #' @param reducedDims The name of the `reducedDims` object (i.e. "IterativeLSI") to use from the designated `ArchRProject`.
 #' @param dimsToUse A vector containing the dimensions from the `reducedDims` object to use in computing the embedding.
-#' @param scaleDims A boolean value that indicates whether to z-score the reduced dimensions for each cell. This is useful for minimizing
-#' the contribution of strong biases (dominating early PCs) and lowly abundant populations. However, this may lead to stronger sample-specific
-#' biases since it is over-weighting latent PCs. If set to `NULL` this will scale the dimensions based on the value of `scaleDims` when the
-#' `reducedDims` were originally created during dimensionality reduction. This idea was introduced by Timothy Stuart.
+#' @param scaleDims A boolean value that indicates whether to z-score the reduced dimensions. The default is set to `NULL`, and will scale the dimensions
+#' based on the value of `scaleDims` when the `reducedDims` were originally created during dimensionality reduction. This idea was introduced by Timothy Stuart.
+#' @param scaleBy A character string indicating if the reduced dimensions should be scaled in either the row direction (default) or the column direction when `scaleDims = TRUE`.
+#' In the case of SVD matrix, the default is to perform scaling for each cell, rather than on the components as in the `signac::RunSVD` implementation.
+#' You can use `scaleBy = "column"` to perform scaling for each component. Like, `scaleDims`, the saved value of `scaleBy` will be used if set to `scaleBy = NULL`.
 #' @param corCutOff A numeric cutoff for the correlation of each dimension to the sequencing depth. If the dimension has a correlation to
 #' sequencing depth that is greater than the `corCutOff`, it will be excluded from analysis.
 #' @param k The number of k-nearest neighbors to use for creating single-cell groups for correlation analyses.
@@ -63,6 +64,7 @@ correlateMatrices <- function(
   reducedDims = "IterativeLSI",
   dimsToUse = 1:30,
   scaleDims = NULL,
+  scaleBy = NULL,
   corCutOff = 0.75,
   k = 100, 
   knnIteration = 500, 
@@ -85,6 +87,7 @@ correlateMatrices <- function(
   .validInput(input = reducedDims, name = "reducedDims", valid = c("character"))
   .validInput(input = dimsToUse, name = "dimsToUse", valid = c("integer", "null"))
   .validInput(input = scaleDims, name = "scaleDims", valid = c("boolean", "null"))
+  .validInput(input = scaleBy, name = "scaleBy", valid = c("character", "null"))
   .validInput(input = corCutOff, name = "corCutOff", valid = c("numeric", "null"))
   .validInput(input = k, name = "k", valid = c("integer"))
   .validInput(input = knnIteration, name = "knnIteration", valid = c("integer"))
@@ -693,10 +696,11 @@ correlateTrajectories <- function(
 #' @param ArchRProj An `ArchRProject` object.
 #' @param reducedDims The name of the `reducedDims` object (i.e. "IterativeLSI") to retrieve from the designated `ArchRProject`.
 #' @param dimsToUse A vector containing the dimensions from the `reducedDims` object to use in clustering.
-#' @param scaleDims A boolean value that indicates whether to z-score the reduced dimensions for each cell. This is useful for minimizing
-#' the contribution of strong biases (dominating early PCs) and lowly abundant populations. However, this may lead to stronger sample-specific
-#' biases since it is over-weighting latent PCs. If set to `NULL` this will scale the dimensions based on the value of `scaleDims` when the
-#' `reducedDims` were originally created during dimensionality reduction. This idea was introduced by Timothy Stuart.
+#' @param scaleDims A boolean value that indicates whether to z-score the reduced dimensions. The default is set to `NULL`, and will scale the dimensions
+#' based on the value of `scaleDims` when the `reducedDims` were originally created during dimensionality reduction. This idea was introduced by Timothy Stuart.
+#' @param scaleBy A character string indicating if the reduced dimensions should be scaled in either the row direction (default) or the column direction when `scaleDims = TRUE`.
+#' In the case of SVD matrix, the default is to perform scaling for each cell, rather than on the components as in the `signac::RunSVD` implementation.
+#' You can use `scaleBy = "column"` to perform scaling for each component. Like, `scaleDims`, the saved value of `scaleBy` will be used if set to `scaleBy = NULL`.
 #' @param corCutOff A numeric cutoff for the correlation of each dimension to the sequencing depth. If the dimension has a correlation to
 #' sequencing depth that is greater than the `corCutOff`, it will be excluded from analysis.
 #' @param cellsToUse A character vector of cellNames to compute coAccessibility on if desired to run on a subset of the total cells.
@@ -729,6 +733,7 @@ addCoAccessibility <- function(
   reducedDims = "IterativeLSI",
   dimsToUse = 1:30,
   scaleDims = NULL,
+  scaleBy = NULL,
   corCutOff = 0.75,
   cellsToUse = NULL,
   excludeChr = NULL,
@@ -748,6 +753,7 @@ addCoAccessibility <- function(
   .validInput(input = reducedDims, name = "reducedDims", valid = c("character"))
   .validInput(input = dimsToUse, name = "dimsToUse", valid = c("numeric", "null"))
   .validInput(input = scaleDims, name = "scaleDims", valid = c("boolean", "null"))
+  .validInput(input = scaleBy, name = "scaleBy", valid = c("character", "null"))
   .validInput(input = corCutOff, name = "corCutOff", valid = c("numeric", "null"))
   .validInput(input = cellsToUse, name = "cellsToUse", valid = c("character", "null"))
   .validInput(input = excludeChr, name = "excludeChr", valid = c("character", "null"))
@@ -1012,10 +1018,11 @@ getCoAccessibility <- function(
 #' @param reducedDims The name of the `reducedDims` object (i.e. "IterativeLSI") to retrieve from the designated `ArchRProject`.
 #' @param useMatrix The name of the matrix containing gene expression information to be used for determining peak-to-gene links. See `getAvailableMatrices(ArchRProj)`
 #' @param dimsToUse A vector containing the dimensions from the `reducedDims` object to use in clustering.
-#' @param scaleDims A boolean value that indicates whether to z-score the reduced dimensions for each cell. This is useful for minimizing
-#' the contribution of strong biases (dominating early PCs) and lowly abundant populations. However, this may lead to stronger sample-specific
-#' biases since it is over-weighting latent PCs. If set to `NULL` this will scale the dimensions based on the value of `scaleDims` when the
-#' `reducedDims` were originally created during dimensionality reduction. This idea was introduced by Timothy Stuart.
+#' @param scaleDims A boolean value that indicates whether to z-score the reduced dimensions. The default is set to `NULL`, and will scale the dimensions
+#' based on the value of `scaleDims` when the `reducedDims` were originally created during dimensionality reduction. This idea was introduced by Timothy Stuart.
+#' @param scaleBy A character string indicating if the reduced dimensions should be scaled in either the row direction (default) or the column direction when `scaleDims = TRUE`.
+#' In the case of SVD matrix, the default is to perform scaling for each cell, rather than on the components as in the `signac::RunSVD` implementation.
+#' You can use `scaleBy = "column"` to perform scaling for each component. Like, `scaleDims`, the saved value of `scaleBy` will be used if set to `scaleBy = NULL`.
 #' @param corCutOff A numeric cutoff for the correlation of each dimension to the sequencing depth. If the dimension has a
 #' correlation to sequencing depth that is greater than the `corCutOff`, it will be excluded from analysis.
 #' @param cellsToUse A character vector of cellNames to compute peak-to-gene links on if desired to run on a subset of the total cells.
@@ -1057,6 +1064,7 @@ addPeak2GeneLinks <- function(
   useMatrix = "GeneIntegrationMatrix",
   dimsToUse = 1:30,
   scaleDims = NULL,
+  scaleBy = NULL,
   corCutOff = 0.75,
   cellsToUse = NULL,
   excludeChr = NULL,
@@ -1081,6 +1089,7 @@ addPeak2GeneLinks <- function(
   .validInput(input = useMatrix, name = "useMatrix", valid = c("character"))
   .validInput(input = dimsToUse, name = "dimsToUse", valid = c("numeric", "null"))
   .validInput(input = scaleDims, name = "scaleDims", valid = c("boolean", "null"))
+  .validInput(input = scaleBy, name = "scaleBy", valid = c("character", "null"))
   .validInput(input = corCutOff, name = "corCutOff", valid = c("numeric", "null"))
   .validInput(input = cellsToUse, name = "cellsToUse", valid = c("character", "null"))
   .validInput(input = excludeChr, name = "excludeChr", valid = c("character", "null"))

--- a/R/IterativeLSI.R
+++ b/R/IterativeLSI.R
@@ -24,9 +24,11 @@
 #' it could impact downstream functionalities including increasing the time required to run `addClusters()`.
 #' @param LSIMethod A number or string indicating the order of operations in the TF-IDF normalization.
 #' Possible values are: 1 or "tf-logidf", 2 or "log(tf-idf)", and 3 or "logtf-logidf".
-#' @param scaleDims A boolean that indicates whether to z-score the reduced dimensions for each cell. This is useful forminimizing the contribution
-#' of strong biases (dominating early PCs) and lowly abundant populations. However, this may lead to stronger sample-specific biases since
-#' it is over-weighting latent PCs.
+#' @param scaleDims A boolean value that indicates whether to z-score the reduced dimensions. The default is to perform scaling on the SVD matrix.
+#' You can use `scaleDims = FALSE` to turn off scaling.
+#' @param scaleBy A character string indicating if the reduced dimensions should be scaled in either the row direction (default) or the column direction when `scaleDims = TRUE`.
+#' In the case of SVD matrix, the default is to perform scaling for each cell, rather than on the components as in the `signac::RunSVD` implementation.
+#' You can use `scaleBy = "column"` to perform scaling for each component.
 #' @param corCutOff A numeric cutoff for the correlation of each dimension to the sequencing depth. If the dimension has a correlation to
 #' sequencing depth that is greater than the `corCutOff`, it will be excluded from analysis.
 #' @param binarize A boolean value indicating whether the matrix should be binarized before running LSI. This is often desired when working with insertion counts.
@@ -90,6 +92,7 @@ addIterativeLSI <- function(
   dimsToUse = 1:30,
   LSIMethod = 2,
   scaleDims = TRUE,
+  scaleBy = "row",
   corCutOff = 0.75,
   binarize = TRUE,
   outlierQuantiles = c(0.02, 0.98),
@@ -130,6 +133,7 @@ addIterativeLSI <- function(
   .validInput(input = dimsToUse, name = "dimsToUse", valid = c("integer"))
   .validInput(input = LSIMethod, name = "LSIMethod", valid = c("integer", "character"))
   .validInput(input = scaleDims, name = "scaleDims", valid = c("boolean"))
+  .validInput(input = scaleBy, name = "scaleBy", valid = c("character"))
   .validInput(input = corCutOff, name = "corCutOff", valid = c("numeric"))
   .validInput(input = binarize, name = "binarize", valid = c("boolean"))
   .validInput(input = outlierQuantiles, name = "outlierQuantiles", valid = c("numeric", "null"))
@@ -152,6 +156,7 @@ addIterativeLSI <- function(
   .validInput(input = force, name = "force", valid = c("boolean"))
   .validInput(input = logFile, name = "logFile", valid = c("character"))
 
+  if(scaleBy != "column") scaleBy <- "row" # default to row-wise scaling
 
   if(varFeatures < 1000){
     stop("Please provide more than 1000 varFeatures!")
@@ -360,6 +365,7 @@ addIterativeLSI <- function(
     useMatrix = useMatrix,
     sampleNames = getCellColData(ArchRProj)$Sample, 
     LSIMethod = LSIMethod, 
+    scaleBy = scaleBy,
     scaleTo = scaleTo,
     dimsToUse = dimsToUse, 
     binarize = binarize, 
@@ -375,6 +381,7 @@ addIterativeLSI <- function(
     logFile = logFile
   )
   outLSI$scaleDims <- scaleDims
+  outLSI$scaleBy <- scaleBy
   outLSI$useMatrix <- useMatrix
   outLSI$tileSize <- tileSize
   gc()
@@ -397,6 +404,7 @@ addIterativeLSI <- function(
     cellDepth = cellDepth,
     dimsToUse = dimsToUse,
     scaleDims = scaleDims,
+    scaleBy = scaleBy,
     corCutOff = corCutOff,
     clusterParams = clusterParams,
     j = j,
@@ -414,7 +422,7 @@ addIterativeLSI <- function(
   #########################
   if(saveIterations){
     .logDiffTime("Saving LSI Iteration", tstart, addHeader = FALSE, verbose = verbose, logFile = logFile)
-    .saveIteration(outLSI=outLSI, clusters=clusters, scaleDims = scaleDims, 
+    .saveIteration(outLSI=outLSI, clusters=clusters, scaleDims = scaleDims, scaleBy = scaleBy,
       dimsToUse = dimsToUse, corCutOff = corCutOff, outDir = outDir,
       nPlot=nPlot, UMAPParams=UMAPParams, ArchRProj=ArchRProj, j = j, threads = threads, logFile = logFile)
   }
@@ -475,6 +483,7 @@ addIterativeLSI <- function(
       cellDepth = cellDepth,
       sampleNames = getCellColData(ArchRProj)$Sample, 
       LSIMethod = LSIMethod, 
+      scaleBy = scaleBy,
       scaleTo = scaleTo, 
       dimsToUse = dimsToUse,
       binarize = binarize,
@@ -490,6 +499,7 @@ addIterativeLSI <- function(
       logFile = logFile
     )
     outLSI$scaleDims <- scaleDims
+    outLSI$scaleBy <- scaleBy
     outLSI$useMatrix <- useMatrix
     outLSI$tileSize <- tileSize
     .logThis(outLSI, paste0("outLSI-",j), logFile = logFile)
@@ -503,6 +513,7 @@ addIterativeLSI <- function(
         outLSI = outLSI,
         dimsToUse = dimsToUse,
         scaleDims = scaleDims,
+	scaleBy = scaleBy,
         corCutOff = corCutOff,
         filterBias = filterBias,
         cellNames = cellNames,
@@ -523,7 +534,7 @@ addIterativeLSI <- function(
       #########################
       if(saveIterations){
         .logDiffTime("Saving LSI Iteration", tstart, addHeader = FALSE, verbose = verbose, logFile = logFile)
-        .saveIteration(outLSI=outLSI, clusters=clusters, scaleDims = scaleDims, 
+        .saveIteration(outLSI=outLSI, clusters=clusters, scaleDims = scaleDims, scaleBy = scaleBy,
           dimsToUse = dimsToUse, corCutOff = corCutOff, outDir = outDir,
           nPlot=nPlot, UMAPParams=UMAPParams, ArchRProj=ArchRProj, j = j, threads = threads, logFile = logFile)
       }
@@ -557,6 +568,7 @@ addIterativeLSI <- function(
   outlierQuantiles = c(0.02, 0.98),
   keep0lsi = FALSE,
   LSIMethod = FALSE,
+  scaleBy = NULL,
   scaleTo = 10^4,
   sampleCells = 5000, 
   projectAll = TRUE,
@@ -609,7 +621,7 @@ addIterativeLSI <- function(
       )
       outLSI$LSIFeatures <- featureDF
       outLSI$corToDepth <- list(
-        scaled = abs(cor(.scaleDims(outLSI[[1]]), cellDepth[rownames(outLSI[[1]])]))[,1],
+        scaled = abs(cor(.scaleDims(outLSI[[1]], scale = scaleBy), cellDepth[rownames(outLSI[[1]])]))[,1],
         none = abs(cor(outLSI[[1]], cellDepth[rownames(outLSI[[1]])]))[,1]
       )
 
@@ -657,7 +669,7 @@ addIterativeLSI <- function(
         )
         outLSI$LSIFeatures <- featureDF
         outLSI$corToDepth <- list(
-          scaled = abs(cor(.scaleDims(outLSI[[1]]), cellDepth[rownames(outLSI[[1]])]))[,1],
+          scaled = abs(cor(.scaleDims(outLSI[[1]], scale = scaleBy), cellDepth[rownames(outLSI[[1]])]))[,1],
           none = abs(cor(outLSI[[1]], cellDepth[rownames(outLSI[[1]])]))[,1]
         )
 
@@ -720,7 +732,7 @@ addIterativeLSI <- function(
 
       outLSI$LSIFeatures <- featureDF
       outLSI$corToDepth <- list(
-        scaled = abs(cor(.scaleDims(outLSI[[1]]), cellDepth[rownames(outLSI[[1]])]))[,1],
+        scaled = abs(cor(.scaleDims(outLSI[[1]], scale = scaleBy), cellDepth[rownames(outLSI[[1]])]))[,1],
         none = abs(cor(outLSI[[1]], cellDepth[rownames(outLSI[[1]])]))[,1]
       )
 
@@ -813,6 +825,7 @@ addIterativeLSI <- function(
   UMAPParams = NULL, 
   ArchRProj = NULL, 
   scaleDims = NULL,
+  scaleBy = NULL,
   corCutOff = NULL,
   dimsToUse = NULL,
   j = NULL,
@@ -844,7 +857,7 @@ addIterativeLSI <- function(
       #Plot Quick UMAP
       UMAPParams <- .mergeParams(UMAPParams, list(n_neighbors = 40, min_dist = 0.4, metric="cosine", verbose=FALSE, fast_sgd = TRUE))
       if(scaleDims){
-        UMAPParams$X <- .scaleDims((outLSI[[1]][saveIdx,,drop=FALSE])[, dimsPF, drop = FALSE])
+        UMAPParams$X <- .scaleDims((outLSI[[1]][saveIdx,,drop=FALSE])[, dimsPF, drop = FALSE], scale = scaleBy)
       }else{
         UMAPParams$X <- (outLSI[[1]][saveIdx,,drop=FALSE])[, dimsPF, drop = FALSE]
       }
@@ -909,6 +922,7 @@ addIterativeLSI <- function(
   corCutOff = NULL,
   dimsToUse = NULL, 
   scaleDims = NULL, 
+  scaleBy = NULL,
   clusterParams = NULL,
   verbose = NULL,
   j = NULL,
@@ -947,7 +961,7 @@ addIterativeLSI <- function(
     })
     parClust$verbose <- FALSE
     if(scaleDims){
-      parClust$input <- .scaleDims(outLSI$matSVD)[, dimsPF, drop = FALSE]
+      parClust$input <- .scaleDims(outLSI$matSVD, scale = scaleBy)[, dimsPF, drop = FALSE]
     }else{
       parClust$input <- outLSI$matSVD[, dimsPF, drop = FALSE]
     }

--- a/R/MultiModal.R
+++ b/R/MultiModal.R
@@ -373,10 +373,11 @@ import10xFeatureMatrix <- function(
 #' @param reducedDims The name of the `reducedDims` objects (i.e. "IterativeLSI") to use from the designated `ArchRProject`.
 #' @param dimWeights A vector of weights to be used to weight each dimensionality reduction when combining.
 #' @param dimsToUse A vector containing the dimensions from the `reducedDims` objects to use.
-#' @param scaleDims A boolean value that indicates whether to z-score the reduced dimensions for each cell. This is useful for minimizing
-#' the contribution of strong biases (dominating early PCs) and lowly abundant populations. However, this may lead to stronger sample-specific
-#' biases since it is over-weighting latent PCs. If set to `NULL` this will scale the dimensions based on the value of `scaleDims` when the
-#' `reducedDims` were originally created during dimensionality reduction. This idea was introduced by Timothy Stuart.
+#' @param scaleDims A boolean value that indicates whether to z-score the reduced dimensions. The default is set to `NULL`, and will scale the dimensions
+#' based on the value of `scaleDims` when the `reducedDims` were originally created during dimensionality reduction. This idea was introduced by Timothy Stuart.
+#' @param scaleBy A character string indicating if the reduced dimensions should be scaled in either the row direction (default) or the column direction when `scaleDims = TRUE`.
+#' In the case of SVD matrix, the default is to perform scaling for each cell, rather than on the components as in the `signac::RunSVD` implementation.
+#' You can use `scaleBy = "column"` to perform scaling for each component. Like, `scaleDims`, the saved value of `scaleBy` will be used if set to `scaleBy = NULL`.
 #' @param corCutOff A numeric cutoff for the correlation of each dimension to the sequencing depth. If the dimension has a correlation to
 #' sequencing depth that is greater than the `corCutOff`, it will be excluded from analysis.
 #' @export
@@ -387,6 +388,7 @@ addCombinedDims <- function(
   dimWeights = NULL,
   dimsToUse = NULL, 
   scaleDims = NULL,
+  scaleBy = NULL,
   corCutOff = 0.75
   ){
 
@@ -400,6 +402,7 @@ addCombinedDims <- function(
       reducedDims = reducedDims[x],
       dimsToUse = dimsToUse,
       scaleDims = scaleDims,
+      scaleBy = scaleBy,
       corCutOff = corCutOff
     )
     cV <- apply(as.matrix(rD), 2, var) 
@@ -409,7 +412,8 @@ addCombinedDims <- function(
   colnames(combinedDims) <- paste0('LSI',1:length(colnames(combinedDims)))
   ArchRProj@reducedDims[[name]] <- SimpleList(
     matRD = combinedDims, 
-    scaleDims = NA, 
+    scaleDims = NA,  # do not scale dims after
+    scaleBy = "row", # set to default
     corToDepth = list(scaled = rep(0, ncol(combinedDims)), none = rep(0, ncol(combinedDims)))
   )
   ArchRProj

--- a/R/ProjectMethods.R
+++ b/R/ProjectMethods.R
@@ -883,10 +883,11 @@ getExons <- function(ArchRProj = NULL, symbols = NULL){
 #' @param returnMatrix If set to "mat" or "matrix", the function will return the `reducedDims` object as a matrix with entries for
 #' each individual cell. Otherwise, it will return the full `reducedDims` object.
 #' @param dimsToUse A vector containing the dimensions (i.e. 1:30) to return from the `reducedDims` object.
-#' @param scaleDims A boolean describing whether to z-score the reduced dimensions for each cell. This is useful for minimizing the
-#' contribution of strong biases (dominating early PCs) and lowly abundant populations. However, this may lead to stronger sample-specific
-#' biases since it is over-weighting latent PCs. If `NULL` this will scale the dimensions depending on if this were set true when the
-#' `reducedDims` were created by the dimensionality reduction method. This idea was introduced by Timothy Stuart.
+#' @param scaleDims A boolean value that indicates whether to z-score the reduced dimensions. The default is set to `NULL`, and will scale the dimensions 
+#' based on the value of `scaleDims` when the `reducedDims` were originally created during dimensionality reduction. This idea was introduced by Timothy Stuart.
+#' @param scaleBy A character string indicating if the reduced dimensions should be scaled in either the row direction (default) or the column direction when `scaleDims = TRUE`.
+#' In the case of SVD matrix, the default is to perform scaling for each cell, rather than on the components as in the `signac::RunSVD` implementation.
+#' You can use `scaleBy = "column"` to perform scaling for each component. Like, `scaleDims`, the saved value of `scaleBy` will be used if set to `scaleBy = NULL`.
 #' @param corCutOff A numeric cutoff for the correlation of each dimension to the sequencing depth. If the dimension has a correlation
 #' to sequencing depth that is greater than the `corCutOff`, it will be excluded.
 #' 
@@ -905,6 +906,7 @@ getReducedDims <- function(
   returnMatrix = TRUE, 
   dimsToUse = NULL,
   scaleDims = NULL,
+  scaleBy = NULL,
   corCutOff = 0.75
   ){
 
@@ -914,6 +916,7 @@ getReducedDims <- function(
   .validInput(input = returnMatrix, name = "returnMatrix", valid = "boolean")
   .validInput(input = dimsToUse, name = "dimsToUse", valid = c("integer", "null"))
   .validInput(input = scaleDims, name = "scaleDims", valid = c("boolean", "null"))
+  .validInput(input = scaleBy, name = "scaleBy", valid = c("character", "null"))
   .validInput(input = corCutOff, name = "corCutOff", valid = c("numeric", "null"))
   #########
 
@@ -929,16 +932,18 @@ getReducedDims <- function(
     
     if(is.na(ArchRProj@reducedDims[[reducedDims]]$scaleDims[1])){
       scaleDims <- FALSE # if na this means dont scaleDims ever.
+      scaleBy <- "row" # set to default
     }
 
     if(is.null(scaleDims)){
       scaleDims <- ArchRProj@reducedDims[[reducedDims]]$scaleDims
+      scaleBy <- ArchRProj@reducedDims[[reducedDims]]$scaleBy
     }
 
     #Get Dimensions
     if(scaleDims){
       corToDepth <- ArchRProj@reducedDims[[reducedDims]]$corToDepth$scaled
-      matDR <- .scaleDims(ArchRProj@reducedDims[[reducedDims]][[1]])
+      matDR <- .scaleDims(ArchRProj@reducedDims[[reducedDims]][[1]], scale = scaleBy)
     }else{
       if(is.na(ArchRProj@reducedDims[[reducedDims]]$corToDepth[1])){
         corToDepth <- rep(0, ncol(ArchRProj@reducedDims[[reducedDims]][[1]]))
@@ -986,11 +991,19 @@ getReducedDims <- function(
 
 }
 
-.scaleDims <- function(x, scaleMax = NULL){
+.scaleDims <- function(x, scale = "row", scaleMax = NULL){
   if(!is.null(scaleMax)){
-    .rowZscores(m=x, min=-scaleMax, max = scaleMax, limit = TRUE)
+    if(scale == "column") {
+      .colZscores(m=x, min=-scaleMax, max = scaleMax, limit = TRUE)
+    } else {
+      .rowZscores(m=x, min=-scaleMax, max = scaleMax, limit = TRUE)
+    }
   }else{
-    .rowZscores(m=x)
+    if(scale == "column") {
+      .colZscores(m=x)
+    } else {
+      .rowZscores(m=x)
+    }
   }
 }
 

--- a/R/RNAIntegration.R
+++ b/R/RNAIntegration.R
@@ -30,10 +30,11 @@
 #' @param embeddingRNA A `data.frame` of cell embeddings such as a UMAP for scRNA-seq cells to be used for density sampling. The `data.frame` object
 #' should have a row for each single cell described in `row.names` and 2 columns, one for each dimension of the embedding.
 #' @param dimsToUse A vector containing the dimensions from the `reducedDims` object to use in clustering.
-#' @param scaleDims A boolean value that indicates whether to z-score the reduced dimensions for each cell. This is useful for minimizing
-#' the contribution of strong biases (dominating early PCs) and lowly abundant populations. However, this may lead to stronger sample-specific
-#' biases since it is over-weighting latent PCs. If set to `NULL` this will scale the dimensions based on the value of `scaleDims` when the
-#' `reducedDims` were originally created during dimensionality reduction. This idea was introduced by Timothy Stuart.
+#' @param scaleDims A boolean value that indicates whether to z-score the reduced dimensions. The default is set to `NULL`, and will scale the dimensions 
+#' based on the value of `scaleDims` when the `reducedDims` were originally created during dimensionality reduction. This idea was introduced by Timothy Stuart.
+#' @param scaleBy A character string indicating if the reduced dimensions should be scaled in either the row direction (default) or the column direction when `scaleDims = TRUE`.
+#' In the case of SVD matrix, the default is to perform scaling for each cell, rather than on the components as in the `signac::RunSVD` implementation.
+#' You can use `scaleBy = "column"` to perform scaling for each component. Like, `scaleDims`, the saved value of `scaleBy` will be used if set to `scaleBy = NULL`.
 #' @param corCutOff A numeric cutoff for the correlation of each dimension to the sequencing depth. If the dimension has a
 #' correlation to sequencing depth that is greater than the `corCutOff`, it will be excluded from analysis.
 #' @param plotUMAP A boolean determining whether to plot a UMAP for each integration block.
@@ -98,6 +99,7 @@ addGeneIntegrationMatrix <- function(
   embeddingRNA = NULL,
   dimsToUse = 1:30,
   scaleDims = NULL,
+  scaleBy = NULL,
   corCutOff = 0.75,
   plotUMAP = TRUE,
   UMAPParams = list(n_neighbors = 40, min_dist = 0.4, metric = "cosine", verbose = FALSE),
@@ -133,6 +135,7 @@ addGeneIntegrationMatrix <- function(
   .validInput(input = reducedDims, name = "reducedDims", valid = c("character"))
   .validInput(input = dimsToUse, name = "dimsToUse", valid = c("numeric", "null"))
   .validInput(input = scaleDims, name = "scaleDims", valid = c("boolean", "null"))
+  .validInput(input = scaleBy, name = "scaleBy", valid = c("character", "null"))
   .validInput(input = plotUMAP, name = "plotUMAP", valid = c("boolean"))
   .validInput(input = UMAPParams, name = "UMAPParams", valid = c("list"))  
   .validInput(input = nGenes, name = "nGenes", valid = c("integer"))
@@ -464,6 +467,7 @@ addGeneIntegrationMatrix <- function(
       imputeParams$reducedDims <- reducedDims
       imputeParams$dimsToUse <- dimsToUse
       imputeParams$scaleDims <- scaleDims
+      imputeParams$scaleBy <- scaleBy
       imputeParams$corCutOff <- corCutOff
       imputeParams$threads <- 1
       imputeParams$logFile <- logFile

--- a/man/addClusters.Rd
+++ b/man/addClusters.Rd
@@ -13,6 +13,7 @@ addClusters(
   method = "Seurat",
   dimsToUse = NULL,
   scaleDims = NULL,
+  scaleBy = NULL,
   corCutOff = 0.75,
   knnAssign = 10,
   nOutlier = 5,
@@ -57,10 +58,12 @@ to keep track of the seed used so that you can reproduce results downstream.}
 
 \item{dimsToUse}{A vector containing the dimensions from the \code{reducedDims} object to use in clustering.}
 
-\item{scaleDims}{A boolean value that indicates whether to z-score the reduced dimensions for each cell. This is useful for minimizing the contribution
-of strong biases (dominating early PCs) and lowly abundant populations. However, this may lead to stronger sample-specific biases since
-it is over-weighting latent PCs. If set to \code{NULL} this will scale the dimensions based on the value of \code{scaleDims} when the \code{reducedDims} were
-originally created during dimensionality reduction. This idea was introduced by Timothy Stuart.}
+\item{scaleDims}{A boolean value that indicates whether to z-score the reduced dimensions. The default is set to \code{NULL}, and will scale the dimensions
+based on the value of \code{scaleDims} when the \code{reducedDims} were originally created during dimensionality reduction. This idea was introduced by Timothy Stuart.}
+
+\item{scaleBy}{A character string indicating if the reduced dimensions should be scaled in either the row direction (default) or the column direction when \code{scaleDims = TRUE}.
+In the case of SVD matrix, the default is to perform scaling for each cell, rather than on the components as in the \code{signac::RunSVD} implementation.
+You can use \code{scaleBy = "column"} to perform scaling for each component. Like, \code{scaleDims}, the saved value of \code{scaleBy} will be used if set to \code{scaleBy = NULL}.}
 
 \item{corCutOff}{A numeric cutoff for the correlation of each dimension to the sequencing depth. If the dimension has a correlation to
 sequencing depth that is greater than the \code{corCutOff}, it will be excluded from analysis.}

--- a/man/addCoAccessibility.Rd
+++ b/man/addCoAccessibility.Rd
@@ -9,6 +9,7 @@ addCoAccessibility(
   reducedDims = "IterativeLSI",
   dimsToUse = 1:30,
   scaleDims = NULL,
+  scaleBy = NULL,
   corCutOff = 0.75,
   cellsToUse = NULL,
   excludeChr = NULL,
@@ -31,10 +32,12 @@ addCoAccessibility(
 
 \item{dimsToUse}{A vector containing the dimensions from the \code{reducedDims} object to use in clustering.}
 
-\item{scaleDims}{A boolean value that indicates whether to z-score the reduced dimensions for each cell. This is useful for minimizing
-the contribution of strong biases (dominating early PCs) and lowly abundant populations. However, this may lead to stronger sample-specific
-biases since it is over-weighting latent PCs. If set to \code{NULL} this will scale the dimensions based on the value of \code{scaleDims} when the
-\code{reducedDims} were originally created during dimensionality reduction. This idea was introduced by Timothy Stuart.}
+\item{scaleDims}{A boolean value that indicates whether to z-score the reduced dimensions. The default is set to \code{NULL}, and will scale the dimensions
+based on the value of \code{scaleDims} when the \code{reducedDims} were originally created during dimensionality reduction. This idea was introduced by Timothy Stuart.}
+
+\item{scaleBy}{A character string indicating if the reduced dimensions should be scaled in either the row direction (default) or the column direction when \code{scaleDims = TRUE}.
+In the case of SVD matrix, the default is to perform scaling for each cell, rather than on the components as in the \code{signac::RunSVD} implementation.
+You can use \code{scaleBy = "column"} to perform scaling for each component. Like, \code{scaleDims}, the saved value of \code{scaleBy} will be used if set to \code{scaleBy = NULL}.}
 
 \item{corCutOff}{A numeric cutoff for the correlation of each dimension to the sequencing depth. If the dimension has a correlation to
 sequencing depth that is greater than the \code{corCutOff}, it will be excluded from analysis.}

--- a/man/addCombinedDims.Rd
+++ b/man/addCombinedDims.Rd
@@ -11,6 +11,7 @@ addCombinedDims(
   dimWeights = NULL,
   dimsToUse = NULL,
   scaleDims = NULL,
+  scaleBy = NULL,
   corCutOff = 0.75
 )
 }
@@ -25,10 +26,12 @@ addCombinedDims(
 
 \item{dimsToUse}{A vector containing the dimensions from the \code{reducedDims} objects to use.}
 
-\item{scaleDims}{A boolean value that indicates whether to z-score the reduced dimensions for each cell. This is useful for minimizing
-the contribution of strong biases (dominating early PCs) and lowly abundant populations. However, this may lead to stronger sample-specific
-biases since it is over-weighting latent PCs. If set to \code{NULL} this will scale the dimensions based on the value of \code{scaleDims} when the
-\code{reducedDims} were originally created during dimensionality reduction. This idea was introduced by Timothy Stuart.}
+\item{scaleDims}{A boolean value that indicates whether to z-score the reduced dimensions. The default is set to \code{NULL}, and will scale the dimensions
+based on the value of \code{scaleDims} when the \code{reducedDims} were originally created during dimensionality reduction. This idea was introduced by Timothy Stuart.}
+
+\item{scaleBy}{A character string indicating if the reduced dimensions should be scaled in either the row direction (default) or the column direction when \code{scaleDims = TRUE}.
+In the case of SVD matrix, the default is to perform scaling for each cell, rather than on the components as in the \code{signac::RunSVD} implementation.
+You can use \code{scaleBy = "column"} to perform scaling for each component. Like, \code{scaleDims}, the saved value of \code{scaleBy} will be used if set to \code{scaleBy = NULL}.}
 
 \item{corCutOff}{A numeric cutoff for the correlation of each dimension to the sequencing depth. If the dimension has a correlation to
 sequencing depth that is greater than the \code{corCutOff}, it will be excluded from analysis.}

--- a/man/addDoubletScores.Rd
+++ b/man/addDoubletScores.Rd
@@ -12,6 +12,7 @@ addDoubletScores(
   dimsToUse = 1:30,
   LSIMethod = 1,
   scaleDims = FALSE,
+  scaleBy = "row",
   corCutOff = 0.75,
   knnMethod = "UMAP",
   UMAPParams = list(n_neighbors = 40, min_dist = 0.4, metric = "euclidean", verbose =
@@ -39,9 +40,12 @@ addDoubletScores(
 \item{LSIMethod}{A number or string indicating the order of operations in the TF-IDF normalization.
 Possible values are: 1 or "tf-logidf", 2 or "log(tf-idf)", and 3 or "logtf-logidf".}
 
-\item{scaleDims}{A boolean that indicates whether to z-score the reduced dimensions for each cell during the LSI
-method performed for doublet determination. This is useful for minimizing the contribution of strong biases (dominating early PCs)
-and lowly abundant populations. However, this may lead to stronger sample-specific biases since it is over-weighting latent PCs.}
+\item{scaleDims}{A boolean value that indicates whether to z-score the reduced dimensions during the LSI method performed for doublet determination.
+The default is to NOT perform scaling on the SVD matrix. You can use \code{scaleDims = TRUE} to turn ON scaling.}
+
+\item{scaleBy}{A character string indicating if the reduced dimensions should be scaled in either the row direction (default) or the column direction when \code{scaleDims = TRUE}.
+In the case of SVD matrix, the default is to perform scaling for each cell, rather than on the components as in the \code{signac::RunSVD} implementation.
+You can use \code{scaleBy = "column"} to perform scaling for each component.}
 
 \item{corCutOff}{A numeric cutoff for the correlation of each dimension to the sequencing depth. If the dimension has a correlation
 to sequencing depth that is greater than the \code{corCutOff}, it will be excluded from analysis.}

--- a/man/addGeneIntegrationMatrix.Rd
+++ b/man/addGeneIntegrationMatrix.Rd
@@ -19,6 +19,7 @@ addGeneIntegrationMatrix(
   embeddingRNA = NULL,
   dimsToUse = 1:30,
   scaleDims = NULL,
+  scaleBy = NULL,
   corCutOff = 0.75,
   plotUMAP = TRUE,
   UMAPParams = list(n_neighbors = 40, min_dist = 0.4, metric = "cosine", verbose = FALSE),
@@ -76,10 +77,12 @@ should have a row for each single cell described in \code{row.names} and 2 colum
 
 \item{dimsToUse}{A vector containing the dimensions from the \code{reducedDims} object to use in clustering.}
 
-\item{scaleDims}{A boolean value that indicates whether to z-score the reduced dimensions for each cell. This is useful for minimizing
-the contribution of strong biases (dominating early PCs) and lowly abundant populations. However, this may lead to stronger sample-specific
-biases since it is over-weighting latent PCs. If set to \code{NULL} this will scale the dimensions based on the value of \code{scaleDims} when the
-\code{reducedDims} were originally created during dimensionality reduction. This idea was introduced by Timothy Stuart.}
+\item{scaleDims}{A boolean value that indicates whether to z-score the reduced dimensions. The default is set to \code{NULL}, and will scale the dimensions
+based on the value of \code{scaleDims} when the \code{reducedDims} were originally created during dimensionality reduction. This idea was introduced by Timothy Stuart.}
+
+\item{scaleBy}{A character string indicating if the reduced dimensions should be scaled in either the row direction (default) or the column direction when \code{scaleDims = TRUE}.
+In the case of SVD matrix, the default is to perform scaling for each cell, rather than on the components as in the \code{signac::RunSVD} implementation.
+You can use \code{scaleBy = "column"} to perform scaling for each component. Like, \code{scaleDims}, the saved value of \code{scaleBy} will be used if set to \code{scaleBy = NULL}.}
 
 \item{corCutOff}{A numeric cutoff for the correlation of each dimension to the sequencing depth. If the dimension has a
 correlation to sequencing depth that is greater than the \code{corCutOff}, it will be excluded from analysis.}

--- a/man/addHarmony.Rd
+++ b/man/addHarmony.Rd
@@ -9,6 +9,7 @@ addHarmony(
   reducedDims = "IterativeLSI",
   dimsToUse = NULL,
   scaleDims = NULL,
+  scaleBy = NULL,
   corCutOff = 0.75,
   name = "Harmony",
   groupBy = "Sample",
@@ -24,10 +25,12 @@ addHarmony(
 
 \item{dimsToUse}{A vector containing the dimensions from the \code{reducedDims} object to use in clustering.}
 
-\item{scaleDims}{A boolean that indicates whether to z-score the reduced dimensions for each cell. This is useful forminimizing the contribution
-of strong biases (dominating early PCs) and lowly abundant populations. However, this may lead to stronger sample-specific biases since
-it is over-weighting latent PCs. If set to \code{NULL} this will scale the dimensions based on the value of \code{scaleDims} when the \code{reducedDims} were
-originally created during dimensionality reduction. This idea was introduced by Timothy Stuart.}
+\item{scaleDims}{A boolean value that indicates whether to z-score the reduced dimensions. The default is set to \code{NULL}, and will scale the dimensions
+based on the value of \code{scaleDims} when the \code{reducedDims} were originally created during dimensionality reduction. This idea was introduced by Timothy Stuart.}
+
+\item{scaleBy}{A character string indicating if the reduced dimensions should be scaled in either the row direction (default) or the column direction when \code{scaleDims = TRUE}.
+In the case of SVD matrix, the default is to perform scaling for each cell, rather than on the components as in the \code{signac::RunSVD} implementation.
+You can use \code{scaleBy = "column"} to perform scaling for each component. Like, \code{scaleDims}, the saved value of \code{scaleBy} will be used if set to \code{scaleBy = NULL}.}
 
 \item{corCutOff}{A numeric cutoff for the correlation of each dimension to the sequencing depth. If the dimension has a correlation
 to sequencing depth that is greater than the \code{corCutOff}, it will be excluded from analysis.}

--- a/man/addImputeWeights.Rd
+++ b/man/addImputeWeights.Rd
@@ -9,6 +9,7 @@ addImputeWeights(
   reducedDims = "IterativeLSI",
   dimsToUse = NULL,
   scaleDims = NULL,
+  scaleBy = NULL,
   corCutOff = 0.75,
   td = 3,
   ka = 4,
@@ -31,10 +32,12 @@ addImputeWeights(
 
 \item{dimsToUse}{A vector containing the dimensions from the \code{reducedDims} object to use.}
 
-\item{scaleDims}{A boolean that indicates whether to z-score the reduced dimensions for each cell. This is useful forminimizing the contribution
-of strong biases (dominating early PCs) and lowly abundant populations. However, this may lead to stronger sample-specific biases since
-it is over-weighting latent PCs. If set to \code{NULL} this will scale the dimensions based on the value of \code{scaleDims} when the \code{reducedDims} were
-originally created during dimensionality reduction. This idea was introduced by Timothy Stuart.}
+\item{scaleDims}{A boolean value that indicates whether to z-score the reduced dimensions. The default is set to \code{NULL}, and will scale the dimensions
+based on the value of \code{scaleDims} when the \code{reducedDims} were originally created during dimensionality reduction. This idea was introduced by Timothy Stuart.}
+
+\item{scaleBy}{A character string indicating if the reduced dimensions should be scaled in either the row direction (default) or the column direction when \code{scaleDims = TRUE}.
+In the case of SVD matrix, the default is to perform scaling for each cell, rather than on the components as in the \code{signac::RunSVD} implementation.
+You can use \code{scaleBy = "column"} to perform scaling for each component. Like, \code{scaleDims}, the saved value of \code{scaleBy} will be used if set to \code{scaleBy = NULL}.}
 
 \item{corCutOff}{A numeric cutoff for the correlation of each dimension to the sequencing depth. If the dimension has a correlation to
 sequencing depth that is greater than the \code{corCutOff}, it will be excluded.}

--- a/man/addIterativeLSI.Rd
+++ b/man/addIterativeLSI.Rd
@@ -17,6 +17,7 @@ addIterativeLSI(
   dimsToUse = 1:30,
   LSIMethod = 2,
   scaleDims = TRUE,
+  scaleBy = "row",
   corCutOff = 0.75,
   binarize = TRUE,
   outlierQuantiles = c(0.02, 0.98),
@@ -70,9 +71,12 @@ it could impact downstream functionalities including increasing the time require
 \item{LSIMethod}{A number or string indicating the order of operations in the TF-IDF normalization.
 Possible values are: 1 or "tf-logidf", 2 or "log(tf-idf)", and 3 or "logtf-logidf".}
 
-\item{scaleDims}{A boolean that indicates whether to z-score the reduced dimensions for each cell. This is useful forminimizing the contribution
-of strong biases (dominating early PCs) and lowly abundant populations. However, this may lead to stronger sample-specific biases since
-it is over-weighting latent PCs.}
+\item{scaleDims}{A boolean value that indicates whether to z-score the reduced dimensions. The default is to perform scaling on the SVD matrix.
+You can use \code{scaleDims = FALSE} to turn off scaling.}
+
+\item{scaleBy}{A character string indicating if the reduced dimensions should be scaled in either the row direction (default) or the column direction when \code{scaleDims = TRUE}.
+In the case of SVD matrix, the default is to perform scaling for each cell, rather than on the components as in the \code{signac::RunSVD} implementation.
+You can use \code{scaleBy = "column"} to perform scaling for each component.}
 
 \item{corCutOff}{A numeric cutoff for the correlation of each dimension to the sequencing depth. If the dimension has a correlation to
 sequencing depth that is greater than the \code{corCutOff}, it will be excluded from analysis.}

--- a/man/addPeak2GeneLinks.Rd
+++ b/man/addPeak2GeneLinks.Rd
@@ -10,6 +10,7 @@ addPeak2GeneLinks(
   useMatrix = "GeneIntegrationMatrix",
   dimsToUse = 1:30,
   scaleDims = NULL,
+  scaleBy = NULL,
   corCutOff = 0.75,
   cellsToUse = NULL,
   excludeChr = NULL,
@@ -38,10 +39,12 @@ addPeak2GeneLinks(
 
 \item{dimsToUse}{A vector containing the dimensions from the \code{reducedDims} object to use in clustering.}
 
-\item{scaleDims}{A boolean value that indicates whether to z-score the reduced dimensions for each cell. This is useful for minimizing
-the contribution of strong biases (dominating early PCs) and lowly abundant populations. However, this may lead to stronger sample-specific
-biases since it is over-weighting latent PCs. If set to \code{NULL} this will scale the dimensions based on the value of \code{scaleDims} when the
-\code{reducedDims} were originally created during dimensionality reduction. This idea was introduced by Timothy Stuart.}
+\item{scaleDims}{A boolean value that indicates whether to z-score the reduced dimensions. The default is set to \code{NULL}, and will scale the dimensions
+based on the value of \code{scaleDims} when the \code{reducedDims} were originally created during dimensionality reduction. This idea was introduced by Timothy Stuart.}
+
+\item{scaleBy}{A character string indicating if the reduced dimensions should be scaled in either the row direction (default) or the column direction when \code{scaleDims = TRUE}.
+In the case of SVD matrix, the default is to perform scaling for each cell, rather than on the components as in the \code{signac::RunSVD} implementation.
+You can use \code{scaleBy = "column"} to perform scaling for each component. Like, \code{scaleDims}, the saved value of \code{scaleBy} will be used if set to \code{scaleBy = NULL}.}
 
 \item{corCutOff}{A numeric cutoff for the correlation of each dimension to the sequencing depth. If the dimension has a
 correlation to sequencing depth that is greater than the \code{corCutOff}, it will be excluded from analysis.}

--- a/man/addTSNE.Rd
+++ b/man/addTSNE.Rd
@@ -14,6 +14,7 @@ addTSNE(
   learningRate = 200,
   dimsToUse = NULL,
   scaleDims = NULL,
+  scaleBy = NULL,
   corCutOff = 0.75,
   saveModel = FALSE,
   verbose = TRUE,
@@ -41,10 +42,12 @@ are "RTSNE", which uses \code{Rtsne::Rtsne()}, and "FFRTSNE", which uses \code{S
 
 \item{dimsToUse}{A vector containing the dimensions from the \code{reducedDims} object to use in computing the embedding.}
 
-\item{scaleDims}{A boolean value that indicates whether to z-score the reduced dimensions for each cell. This is useful for minimizing
-the contribution of strong biases (dominating early PCs) and lowly abundant populations. However, this may lead to stronger sample-specific
-biases since it is over-weighting latent PCs. If set to \code{NULL} this will scale the dimensions based on the value of \code{scaleDims} when the
-\code{reducedDims} were originally created during dimensionality reduction. This idea was introduced by Timothy Stuart.}
+\item{scaleDims}{A boolean value that indicates whether to z-score the reduced dimensions. The default is set to \code{NULL}, and will scale the dimensions
+based on the value of \code{scaleDims} when the \code{reducedDims} were originally created during dimensionality reduction. This idea was introduced by Timothy Stuart.}
+
+\item{scaleBy}{A character string indicating if the reduced dimensions should be scaled in either the row direction (default) or the column direction when \code{scaleDims = TRUE}.
+In the case of SVD matrix, the default is to perform scaling for each cell, rather than on the components as in the \code{signac::RunSVD} implementation.
+You can use \code{scaleBy = "column"} to perform scaling for each component. Like, \code{scaleDims}, the saved value of \code{scaleBy} will be used if set to \code{scaleBy = NULL}.}
 
 \item{corCutOff}{A numeric cutoff for the correlation of each dimension to the sequencing depth. If the dimension has a correlation to sequencing
 depth that is greater than the \code{corCutOff}, it will be excluded from analysis.}

--- a/man/addUMAP.Rd
+++ b/man/addUMAP.Rd
@@ -13,6 +13,7 @@ addUMAP(
   metric = "cosine",
   dimsToUse = NULL,
   scaleDims = NULL,
+  scaleBy = NULL,
   corCutOff = 0.75,
   sampleCells = NULL,
   outlierQuantile = 0.9,
@@ -40,10 +41,12 @@ addUMAP(
 
 \item{dimsToUse}{A vector containing the dimensions from the \code{reducedDims} object to use in computing the embedding.}
 
-\item{scaleDims}{A boolean value that indicates whether to z-score the reduced dimensions for each cell. This is useful for minimizing
-the contribution of strong biases (dominating early PCs) and lowly abundant populations. However, this may lead to stronger sample-specific
-biases since it is over-weighting latent PCs. If set to \code{NULL} this will scale the dimensions based on the value of \code{scaleDims} when the
-\code{reducedDims} were originally created during dimensionality reduction. This idea was introduced by Timothy Stuart.}
+\item{scaleDims}{A boolean value that indicates whether to z-score the reduced dimensions. The default is set to \code{NULL}, and will scale the dimensions
+based on the value of \code{scaleDims} when the \code{reducedDims} were originally created during dimensionality reduction. This idea was introduced by Timothy Stuart.}
+
+\item{scaleBy}{A character string indicating if the reduced dimensions should be scaled in either the row direction (default) or the column direction when \code{scaleDims = TRUE}.
+In the case of SVD matrix, the default is to perform scaling for each cell, rather than on the components as in the \code{signac::RunSVD} implementation.
+You can use \code{scaleBy = "column"} to perform scaling for each component. Like, \code{scaleDims}, the saved value of \code{scaleBy} will be used if set to \code{scaleBy = NULL}.}
 
 \item{corCutOff}{A numeric cutoff for the correlation of each dimension to the sequencing depth. If the dimension has a correlation to
 sequencing depth that is greater than the \code{corCutOff}, it will be excluded from analysis.}

--- a/man/correlateMatrices.Rd
+++ b/man/correlateMatrices.Rd
@@ -17,6 +17,7 @@ correlateMatrices(
   reducedDims = "IterativeLSI",
   dimsToUse = 1:30,
   scaleDims = NULL,
+  scaleBy = NULL,
   corCutOff = 0.75,
   k = 100,
   knnIteration = 500,
@@ -52,10 +53,12 @@ Options include "underscore", "dash", "numeric" and "dot". The string portion pr
 
 \item{dimsToUse}{A vector containing the dimensions from the \code{reducedDims} object to use in computing the embedding.}
 
-\item{scaleDims}{A boolean value that indicates whether to z-score the reduced dimensions for each cell. This is useful for minimizing
-the contribution of strong biases (dominating early PCs) and lowly abundant populations. However, this may lead to stronger sample-specific
-biases since it is over-weighting latent PCs. If set to \code{NULL} this will scale the dimensions based on the value of \code{scaleDims} when the
-\code{reducedDims} were originally created during dimensionality reduction. This idea was introduced by Timothy Stuart.}
+\item{scaleDims}{A boolean value that indicates whether to z-score the reduced dimensions. The default is set to \code{NULL}, and will scale the dimensions
+based on the value of \code{scaleDims} when the \code{reducedDims} were originally created during dimensionality reduction. This idea was introduced by Timothy Stuart.}
+
+\item{scaleBy}{A character string indicating if the reduced dimensions should be scaled in either the row direction (default) or the column direction when \code{scaleDims = TRUE}.
+In the case of SVD matrix, the default is to perform scaling for each cell, rather than on the components as in the \code{signac::RunSVD} implementation.
+You can use \code{scaleBy = "column"} to perform scaling for each component. Like, \code{scaleDims}, the saved value of \code{scaleBy} will be used if set to \code{scaleBy = NULL}.}
 
 \item{corCutOff}{A numeric cutoff for the correlation of each dimension to the sequencing depth. If the dimension has a correlation to
 sequencing depth that is greater than the \code{corCutOff}, it will be excluded from analysis.}

--- a/man/getReducedDims.Rd
+++ b/man/getReducedDims.Rd
@@ -10,6 +10,7 @@ getReducedDims(
   returnMatrix = TRUE,
   dimsToUse = NULL,
   scaleDims = NULL,
+  scaleBy = NULL,
   corCutOff = 0.75
 )
 }
@@ -23,10 +24,12 @@ each individual cell. Otherwise, it will return the full \code{reducedDims} obje
 
 \item{dimsToUse}{A vector containing the dimensions (i.e. 1:30) to return from the \code{reducedDims} object.}
 
-\item{scaleDims}{A boolean describing whether to z-score the reduced dimensions for each cell. This is useful for minimizing the
-contribution of strong biases (dominating early PCs) and lowly abundant populations. However, this may lead to stronger sample-specific
-biases since it is over-weighting latent PCs. If \code{NULL} this will scale the dimensions depending on if this were set true when the
-\code{reducedDims} were created by the dimensionality reduction method. This idea was introduced by Timothy Stuart.}
+\item{scaleDims}{A boolean value that indicates whether to z-score the reduced dimensions. The default is set to \code{NULL}, and will scale the dimensions
+based on the value of \code{scaleDims} when the \code{reducedDims} were originally created during dimensionality reduction. This idea was introduced by Timothy Stuart.}
+
+\item{scaleBy}{A character string indicating if the reduced dimensions should be scaled in either the row direction (default) or the column direction when \code{scaleDims = TRUE}.
+In the case of SVD matrix, the default is to perform scaling for each cell, rather than on the components as in the \code{signac::RunSVD} implementation.
+You can use \code{scaleBy = "column"} to perform scaling for each component. Like, \code{scaleDims}, the saved value of \code{scaleBy} will be used if set to \code{scaleBy = NULL}.}
 
 \item{corCutOff}{A numeric cutoff for the correlation of each dimension to the sequencing depth. If the dimension has a correlation
 to sequencing depth that is greater than the \code{corCutOff}, it will be excluded.}


### PR DESCRIPTION
This PR aads a `scaleBy` to allow user to select z-score scaling of LSI matrix in a column-wise fashing.

As noted in the commit message, the default scaling implemented by ArchR (through `scaleDims = TRUE`) is performed on cells (row-scaled). When UMAP and TSNE and clustering are performed using the row-scaled (or unscaled) matrix, this often results in embeddings and clusters that are not optimal in terms of biological relevance.

This issue had been raised by Danny Conrad here: https://github.com/GreenleafLab/ArchR/issues/2120

Below are plots to demonstrate how different scaling settings affect the results.
The cells had been manually curated using the GEX data with cell type label added.

**Example A**
```
# scaling ON, scaled by row (cells); default
scaleDims = TRUE
scaleBy = "row"
```
<img width="1920" height="600" alt="Example A" src="https://github.com/user-attachments/assets/8f6bda3d-00f0-4d06-a42f-de64cb90afed" />

**Example B**
```
# scaling OFF
scaleDims = FALSE
```
<img width="1920" height="600" alt="Example B" src="https://github.com/user-attachments/assets/e63c3eb3-4582-4f6b-96b9-41230527a15f" />

**Example C**
```
# scaling ON, scaled by column (components)
scaleDims = TRUE
scaleBy = "column"
```
<img width="1920" height="600" alt="Example C" src="https://github.com/user-attachments/assets/3cf38f5d-96f5-4c6c-8a59-cf311b3bebc9" />
