### PR TITLE
Fix input type validation of scaleBy to character

### DIFF
--- a/R/DoubletsScores.R
+++ b/R/DoubletsScores.R
@@ -71,7 +71,7 @@ addDoubletScores <- function(
   .validInput(input = dimsToUse, name = "dimsToUse", valid = c("integer", "null"))
   .validInput(input = corCutOff, name = "corCutOff", valid = c("numeric", "null"))
   .validInput(input = scaleDims, name = "scaleDims", valid = c("boolean"))
-  .validInput(input = scaleBy, name = "scaleBy", valid = c("boolean"))
+  .validInput(input = scaleBy, name = "scaleBy", valid = c("character"))
   .validInput(input = knnMethod, name = "knnMethod", valid = c("character"))
   .validInput(input = UMAPParams, name = "UMAPParams", valid = c("list"))
   .validInput(input = LSIParams, name = "LSIParams", valid = c("list"))


### PR DESCRIPTION
The PR fix a bug with the `scaleBy` data type during validation.

```
  .validInput(input = scaleBy, name = "scaleBy", valid = c("character"))
```